### PR TITLE
Fix links and add navigation

### DIFF
--- a/assets/Style_sub.css
+++ b/assets/Style_sub.css
@@ -160,3 +160,7 @@ h3 {
     margin-top: 15px;
     margin-bottom: 20px;
 }
+.nav-links { text-align: center; margin-top: 30px; margin-bottom: 20px; }
+.nav-links a { margin: 0 10px; color: #0056b3; text-decoration: none; }
+.nav-links a:hover { text-decoration: underline; }
+

--- a/contents/LSC/LSC_Musing_Log_Part1.html
+++ b/contents/LSC/LSC_Musing_Log_Part1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>LSC Musing Log Part 1</title>
-<link rel="stylesheet" type="text/css" href="../assets/style_LOG.css">
+<link rel="stylesheet" type="text/css" href="../../assets/Style_LOG.css">
 </head>
 <body>
 
@@ -20,7 +20,7 @@
     <ul>
       <li>They're all about quick wins, short-term profits, and keeping shareholders happy above all else.</li>
       <li>Sometimes, they act like vultures, you know? Swooping in, buying up companies, and tearing them apart for profit, even if it wrecks the real economy. (Think financial markets going wild, basically attacking the real-world stuff).</li>
-      <li>This kind of behavior can mess things up بد؛ like, no one wants to invest for the long haul, companies slash jobs so people can't buy as much, subcontractors get squeezed, and who cares about doing good for society, right?</li>
+      <li>This kind of behavior can mess things up bad; like, no one wants to invest for the long haul, companies slash jobs so people can't buy as much, subcontractors get squeezed, and who cares about doing good for society, right?</li>
     </ul>
     <p><strong>Why the Real Economy Actually Matters:</strong></p>
     <ul>
@@ -42,7 +42,7 @@
   </div>
 
   <div class="message question">
-    <p>Okay, I wanna brainstorm some points. Could you whip up a conversation сценарий like this:</p>
+    <p>Okay, I wanna brainstorm some points. Could you whip up a conversation script like this:</p>
     <p>Mr. Finance and Mr. Real (Mr. F is the financial markets, Mr. R is the real economy, obviously)</p>
     <p>They do the polite intro thing (Mr. R, Mr. F, one's older, one's younger).</p>
     <p>Mr. R's take on Mr. F (kinda like a history lesson on financial markets).</p>

--- a/contents/LSC/LSC_Musing_Log_Part2.html
+++ b/contents/LSC/LSC_Musing_Log_Part2.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>LSC Musing Log Part 2</title>
-<link rel="stylesheet" type="text/css" href="../assets/style_LOG.css">
+<link rel="stylesheet" type="text/css" href="../../assets/Style_LOG.css">
 </head>
 <body>
 

--- a/contents/LSC/LSC_Musing_Log_Part3.html
+++ b/contents/LSC/LSC_Musing_Log_Part3.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>LSC Musing Log Part 3</title>
-<link rel="stylesheet" type="text/css" href="../assets/style_LOG.css">
+<link rel="stylesheet" type="text/css" href="../../assets/Style_LOG.css">
 </head>
 <body>
 

--- a/contents/LSC/Libra_Scales_Capitalism_Core_Concept.html
+++ b/contents/LSC/Libra_Scales_Capitalism_Core_Concept.html
@@ -3,7 +3,7 @@
 <head>
    <meta charset="UTF-8">
    <title>Libra/Scales Capitalism (LSC) Core Concept Explained</title>
-   <link rel="stylesheet" type="text/css" href="assets/css/style_ENG.css">
+   <link rel="stylesheet" type="text/css" href="../../assets/Style_contents.css">
 </head>
 <body>
    <div class="container">

--- a/contents/LSC/Libra_Scales_Capitalism_Manifesto.html
+++ b/contents/LSC/Libra_Scales_Capitalism_Manifesto.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Libra/Scales Capitalism Manifesto</title>
-    <link rel="stylesheet" type="text/css" href="assets/css/style_ENG.css">
+    <link rel="stylesheet" type="text/css" href="../../assets/Style_contents.css">
 </head>
 <body>
     <div class="container">

--- a/contents/LSC/index.html
+++ b/contents/LSC/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Libra/Scales Capitalism Resources</title>
+  <link rel="stylesheet" href="../../assets/Style_sub.css">
+</head>
+<body>
+  <div class="page-container">
+    <header>
+      <h1>Libra/Scales Capitalism Resources</h1>
+    </header>
+    <div class="content-padding">
+      <nav class="article-list">
+        <ul>
+          <li><a href="./Libra_Scales_Capitalism_Core_Concept.html">LSC Core Concept</a></li>
+          <li><a href="./Libra_Scales_Capitalism_Manifesto.html">LSC Manifesto</a></li>
+          <li><a href="./LSC_Musing_Log_Part1.html">LSC Musing Log Part&nbsp;1</a></li>
+          <li><a href="./LSC_Musing_Log_Part2.html">LSC Musing Log Part&nbsp;2</a></li>
+          <li><a href="./LSC_Musing_Log_Part3.html">LSC Musing Log Part&nbsp;3</a></li>
+          <li><a href="./Hope-Infrastructure.md">Hope Infrastructure (Markdown)</a></li>
+        </ul>
+      </nav>
+    </div>
+    <footer>
+      <p><a href="../../index.html">Back to Home</a></p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._1.html
+++ b/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._1.html
@@ -171,6 +171,7 @@ graph TD
 
     </div>
 
+    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._2.html">Next &raquo;</a></div>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script>mermaid.initialize({startOnLoad:true});</script>
 </body>

--- a/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._2.html
+++ b/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._2.html
@@ -186,6 +186,7 @@ graph TD
 
     </div>
 
+    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._1.html">&laquo; Previous</a> | <a href="Ministry of Finance - The true ruler that controls all of Japan._3.html">Next &raquo;</a></div>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script>mermaid.initialize({startOnLoad:true});</script>
 </body>

--- a/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._3.html
+++ b/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._3.html
@@ -146,6 +146,7 @@
 
     </div>
 
+    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._2.html">&laquo; Previous</a> | <a href="Ministry of Finance - The true ruler that controls all of Japan._4.html">Next &raquo;</a></div>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script>mermaid.initialize({startOnLoad:true});</script>
 </body>

--- a/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._4.html
+++ b/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._4.html
@@ -193,6 +193,7 @@
         </ul>
     </div>
 
+    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._3.html">&laquo; Previous</a> | <a href="index.html">Back to Index</a></div>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script>mermaid.initialize({startOnLoad:true});</script>
 </body>

--- a/index.json
+++ b/index.json
@@ -1,0 +1,16 @@
+[
+  "README.md",
+  "contents/LSC/Hope-Infrastructure.md",
+  "contents/LSC/LSC_Musing_Log_Part1.html",
+  "contents/LSC/LSC_Musing_Log_Part2.html",
+  "contents/LSC/LSC_Musing_Log_Part3.html",
+  "contents/LSC/Libra_Scales_Capitalism_Core_Concept.html",
+  "contents/LSC/Libra_Scales_Capitalism_Manifesto.html",
+  "contents/LSC/index.html",
+  "contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._1.html",
+  "contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._2.html",
+  "contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._3.html",
+  "contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._4.html",
+  "contents/MOF/index.html",
+  "index.html"
+]

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -1,0 +1,14 @@
+./README.md
+./contents/LSC/Hope-Infrastructure.md
+./contents/LSC/LSC_Musing_Log_Part1.html
+./contents/LSC/LSC_Musing_Log_Part2.html
+./contents/LSC/LSC_Musing_Log_Part3.html
+./contents/LSC/Libra_Scales_Capitalism_Core_Concept.html
+./contents/LSC/Libra_Scales_Capitalism_Manifesto.html
+./contents/LSC/index.html
+./contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._1.html
+./contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._2.html
+./contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._3.html
+./contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._4.html
+./contents/MOF/index.html
+./index.html


### PR DESCRIPTION
## Summary
- add missing index page for LSC section
- correct stylesheet paths in LSC pages and fix typos
- add simple next/previous navigation for MOF articles
- add small navigation style to `Style_sub.css`
- generate `sitemap.txt` and `index.json` for automation

## Testing
- `grep -n "contents/LSC" index.html`


------
https://chatgpt.com/codex/tasks/task_e_685063744b608333ad0c9d4da82a3015