### PR TITLE
Fix MOF English navigation

### DIFF
--- a/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._1-en.html
+++ b/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._1-en.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../../assets/Style_sub.css">
     <title>[Commentary Report] Who Moves Japanese Politics? The Influence of the Ministry of Finance</title>
     <style>
         body {
@@ -171,7 +172,7 @@ graph TD
 
     </div>
 
-    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._2.html">Next &raquo;</a></div>
+    <div class="nav-links"><a href="index-en.html">Back to Index</a> | <a href="Ministry of Finance - The true ruler that controls all of Japan._2-en.html">Next &raquo;</a></div>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script>mermaid.initialize({startOnLoad:true});</script>
 </body>

--- a/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._2-en.html
+++ b/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._2-en.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../../assets/Style_sub.css">
     <title>[Commentary Report] Who Moves Japanese Politics? The Influence of the Ministry of Finance (Part 2)</title>
     <style>
         body {
@@ -97,6 +98,8 @@
 <body>
     <div class="container">
 
+        <h1>[Commentary Report]<br>Who Moves Japanese Politics?<br>The Ministry of Finance's Influence (Part 2)</h1>
+
         <h2>III. The Bureaucracy and the Ministry of Finance: Apparent Weakening and Subtle Control</h2>
 
         <h3>A. What Is the Bureaucrats' Real Power?—Expert Knowledge and Possible Information Control</h3>
@@ -186,7 +189,7 @@ graph TD
 
     </div>
 
-    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._1.html">&laquo; Previous</a> | <a href="Ministry of Finance - The true ruler that controls all of Japan._3.html">Next &raquo;</a></div>
+    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._1-en.html">&laquo; Previous</a> | <a href="index-en.html">Back to Index</a> | <a href="Ministry of Finance - The true ruler that controls all of Japan._3-en.html">Next &raquo;</a></div>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script>mermaid.initialize({startOnLoad:true});</script>
 </body>

--- a/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._3-en.html
+++ b/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._3-en.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../../assets/Style_sub.css">
     <title>[Commentary Report] Who Moves Japanese Politics? The Influence of the Ministry of Finance (Part 3)</title>
     <style>
         body {
@@ -97,6 +98,8 @@
 <body>
     <div class="container">
 
+        <h1>[Commentary Report]<br>Who Moves Japanese Politics?<br>The Ministry of Finance's Influence (Part 3)</h1>
+
         <h2>V. Can Politicians Resist?—Attempts at "Political Leadership" and Their Limits</h2>
 
         <h3>A. Efforts by Politicians—Those Who Seriously Tried to Change Things</h3>
@@ -145,7 +148,7 @@
 
     </div>
 
-    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._2.html">&laquo; Previous</a> | <a href="Ministry of Finance - The true ruler that controls all of Japan._4.html">Next &raquo;</a></div>
+    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._2-en.html">&laquo; Previous</a> | <a href="index-en.html">Back to Index</a> | <a href="Ministry of Finance - The true ruler that controls all of Japan._4-en.html">Next &raquo;</a></div>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script>mermaid.initialize({startOnLoad:true});</script>
 </body>

--- a/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._4-en.html
+++ b/contents/MOF/Ministry of Finance - The true ruler that controls all of Japan._4-en.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../../assets/Style_sub.css">
     <title>[Commentary Report] Who Moves Japanese Politics? The Influence of the Ministry of Finance (Final)</title>
     <style>
         body {
@@ -101,6 +102,8 @@
 <body>
     <div class="container">
 
+        <h1>[Commentary Report]<br>Who Moves Japanese Politics?<br>The Ministry of Finance's Influence (Final)</h1>
+
         <h2>VII. Analysis: Just How Powerful Is the Ministry?</h2>
 
         <h3>A. The Gap Between Constitutional Rules and Reality</h3>
@@ -192,7 +195,7 @@
         </ul>
     </div>
 
-    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._3.html">&laquo; Previous</a> | <a href="index.html">Back to Index</a></div>
+    <div class="nav-links"><a href="Ministry of Finance - The true ruler that controls all of Japan._3-en.html">&laquo; Previous</a> | <a href="index-en.html">Back to Index</a></div>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script>mermaid.initialize({startOnLoad:true});</script>
 </body>


### PR DESCRIPTION
## Summary
- improve stylesheet usage for MOF English pages
- add missing `<h1>` headers for parts 2–4
- correct previous/next navigation links and add link back to English index

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68506e70917483339fd675b35196df1d