### PR TITLE
Fix: Adjust politician section layout and paths (local structure priority)

### DIFF
--- a/assets/Style_contents.css
+++ b/assets/Style_contents.css
@@ -275,12 +275,16 @@ caption {
 }
 
 .header-image {
-    width: 100%;
-    height: auto;
-    aspect-ratio: 16 / 9;
-    object-fit: cover;
-    display: block;
-    margin-bottom: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  display: block;
+  margin: 0 auto;
+}
+
+.page-container {
+  max-width: 960px;
+  margin: auto;
+  padding: 1em;
 }

--- a/assets/Style_sub.css
+++ b/assets/Style_sub.css
@@ -126,18 +126,10 @@ footer a:hover {
 	font-weight: bold;
 }
 .prerequisite-black {
-	color: black;
-	font-size: 1em; /* 普通の大きさ */
-	text-align: left;
-	margin-bottom: 1em;
-}
-footer {
-	text-align: center;
-	margin-top: 40px;
-	padding-top: 20px;
-	border-top: 1px solid #ccc;
-	font-size: 0.9em;
-	color: #666;
+        color: black;
+        font-size: 1em; /* 普通の大きさ */
+        text-align: left;
+        margin-bottom: 1em;
 }
 
 /* === 以下は、以前のStyle_sub.cssにあったが、Normalのindex.htmlのスタイルに統合・調整されたもの === */
@@ -163,4 +155,20 @@ h3 {
 .nav-links { text-align: center; margin-top: 30px; margin-bottom: 20px; }
 .nav-links a { margin: 0 10px; color: #0056b3; text-decoration: none; }
 .nav-links a:hover { text-decoration: underline; }
+
+/* layout helpers */
+.header-image {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  display: block;
+  margin: 0 auto;
+}
+
+.page-container {
+  max-width: 960px;
+  margin: auto;
+  padding: 1em;
+}
 

--- a/contents/politician/LDP/Shinjiro Koizumi.html
+++ b/contents/politician/LDP/Shinjiro Koizumi.html
@@ -5,11 +5,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Shinjiro Koizumi - Critical Review</title>
-  <link rel="stylesheet" href="../../../../assets/Style_contents.css" />
+  <link rel="stylesheet" href="../../../assets/Style_contents.css" />
 </head>
 <body>
+  <div class="page-wrapper">
   <header>
-    <img src="../../../../assets/images/shinjiro_koizumi.webp" alt="Shinjiro Koizumi" class="header-image" />
+    <img src="../../../assets/images/shinjiro_koizumi.webp" alt="Shinjiro Koizumi" class="header-image" />
     <h1>Shinjiro Koizumi</h1>
     <p>Member of the Liberal Democratic Party (LDP), former Minister of the Environment</p>
   </header>
@@ -56,5 +57,6 @@
       <p><a href="../index.html">&larr; Back to Politician List</a></p>
     </footer>
   </main>
+  </div>
 </body>
 </html>

--- a/contents/politician/index.html
+++ b/contents/politician/index.html
@@ -8,8 +8,9 @@
   <link rel="stylesheet" href="../../assets/Style_sub.css" />
 </head>
 <body>
+  <div class="page-container">
   <header>
-    <img src="../../assets/images/menbers.webp" alt="Japanese Politician Insights" class=".page-main-image img" />
+    <img src="../../assets/images/menbers.webp" alt="Japanese Politician Insights" class="header-image" />
     <h1>Japanese Politician Insights</h1>
     <p>A non-ideological, fact-based review of major political figures in Japan.</p>
   </header>
@@ -19,7 +20,7 @@
       <h2>Liberal Democratic Party (LDP)</h2>
       <ul>
         <li>
-          <a href="./LDP/Shinjiro Koizumi.html">Shinjiro Koizumi: A Critical Review</a>
+          <a href="LDP/Shinjiro Koizumi.html">Shinjiro Koizumi: A Critical Review</a>
         </li>
       </ul>
     </section>
@@ -29,5 +30,9 @@
       <p>Additional profiles of Japanese politicians will be added progressively.</p>
     </section>
   </main>
+  <footer>
+    <p>&copy; 2025 Elementary Particles Man</p>
+  </footer>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix relative paths on politician pages
- unify layout wrappers and header images
- remove duplicated footer style
- add shared layout helpers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850895c213883339bf036ddeef6f968