### PR TITLE
Add Horizon Protocol HTML docs and update metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>International Information</title>
+  <meta name="description" content="The Horizon Protocol（THP）の公開ドキュメント集。ワルプルギス Ver.2.0、E-MAD/E-Penaltyの非暴力原則、Ops-KPIなど。">
+  <title>Particle Musings — The Horizon Protocol</title>
   <link rel="stylesheet" href="./assets/Style_root.css">
 </head>
 <body>

--- a/thp/html/emad-spec.html
+++ b/thp/html/emad-spec.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>E-MAD仕様 — Effective Multilateral Assured Denial</title>
+  <meta name="description" content="E-MADの正式仕様。非暴力抑止の設計原理と運用要件を定義。E-Penaltyはミクロ秩序維持として外部設計。">
+  <link rel="stylesheet" href="../styles/thp.css">
+</head>
+<body>
+  <header>
+    <h1>E-MAD仕様</h1>
+    <p class="note">本仕様はE-MAD（Effective Multilateral Assured Denial）の正本です。E-Penaltyは別途、各地域統括×対象国の協議に基づく非暴力的措置として設計され、THPコアには実装しません。</p>
+  </header>
+  <main>
+    <section>
+      <h2>目的</h2>
+      <p>Effective Multilateral Assured Denialは、武力衝突を事前に無効化するための多国間協調システムです。情報・資源・インフラの共有レイヤを整備し、危機要因を速やかに減衰させます。</p>
+    </section>
+
+    <section>
+      <h2>運用要件</h2>
+      <ul>
+        <li>透明性: すべての介入はログ化され、共同監査に付される。</li>
+        <li>即応性: 初期兆候の検知から24時間以内に協調対話チャネルを開設。</li>
+        <li>人道優先: 非暴力であることを最優先し、市民保護を常に先置きする。</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>インターフェース</h2>
+      <p>E-MAD API群は、各国の監視・判断システムと連携するための標準化プロトコルを提供します。信頼スコア、リスクシグナル、調停結果をリアルタイムで同期することが求められます。</p>
+    </section>
+  </main>
+  <footer>
+    <hr>
+    <p class="foot-link">用語集: <a href="/thp/html/thp-5-glossary.html">THP-5</a></p>
+  </footer>
+</body>
+</html>

--- a/thp/html/index-ja.html
+++ b/thp/html/index-ja.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>THP HTML Edition（日本語）— 目次</title>
+  <meta name="description" content="THPの日本語HTML版インデックス。E-MAD/E-Penaltyの表記統一、ワルプルギス Ver.2.0定義、各章への導線を整理。">
+  <link rel="stylesheet" href="../styles/thp.css">
+</head>
+<body>
+  <header>
+    <h1>THP HTML Edition — 目次</h1>
+  </header>
+  <main>
+    <p>本インデックスは、THP各章および関連資料への導線をまとめています。E-MAD仕様（Effective Multilateral Assured Denial）の更新に伴い、用語統一を実施しました。</p>
+    <ul class="toc">
+      <li><a href="part1.html">THP Part1 — 概説 / ワルプルギス Ver.2.0</a></li>
+      <li><a href="part2.html">THP Part2 — 実装指針 / E-Penaltyの非暴力原則</a></li>
+      <li><a href="emad-spec.html">E-MAD仕様（Effective Multilateral Assured Denial）</a></li>
+      <li><a href="thp-5-glossary.html">THP-5 — 用語集</a></li>
+      <li><a href="thp-7-ops-kpi.html">THP-7 — Ops KPI Dashboard</a></li>
+      <li><span>最終更新: <time datetime="2025-09-27">2025-09-27</time></span> / <span>版: rev-2025.09.27</span></li>
+    </ul>
+  </main>
+  <footer>
+    <hr>
+    <p class="foot-link">用語が不明な場合は <a href="/thp/html/thp-5-glossary.html">THP-5 用語集</a> を参照。</p>
+  </footer>
+</body>
+</html>

--- a/thp/html/part1.html
+++ b/thp/html/part1.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>THP Part1 — 概説 / ワルプルギス Ver.2.0</title>
+  <meta name="description" content="THPの概説。単発崩壊ではなく構造的・多起点ショック（ワルプルギス Ver.2.0）に備える設計思想と非暴力的抑止（E-MAD）/E-Penaltyの位置付けを明確化。">
+  <link rel="stylesheet" href="../styles/thp.css">
+</head>
+<body>
+  <header>
+    <h1>THP Part1 — 概説</h1>
+  </header>
+  <main>
+    <p>THPは、特定日付の単発崩壊ではなく、内外の断層が連鎖して顕在化する“構造的・多起点ショック（ワルプルギス Ver.2.0）”を前提に、社会・市場・人道の同時安定化を設計する実装フレームです。</p>
+
+    <section>
+      <h2>E-MADとは</h2>
+      <p class="note">表記統一: 本サイトでは E-MAD = <strong>Effective Multilateral Assured Denial</strong>（戦争抑止の非暴力メカニズム）、E-Penalty = <strong>非暴力的ペナルティ体系</strong>（リスクプレミアム・信用スコア調整等）とします。E-Penaltyは“ミクロ秩序維持”領域であり、THPコアには実装しません。各地域統括と対象国が協議の上、<em>透明・公平・正確（罪と罰の整合）</em>で設計してください。</p>
+      <p class="note">※ 実装の正本は「E-MAD仕様（技術文書）」を参照のこと。</p>
+      <p>Effective Multilateral Assured Denial（E-MAD）は、複数国家・地域の協調によって戦争抑止を図る非暴力的な抑止メカニズムです。経済・情報・インフラを相互に連結させ、危機発火点を先回りして制御します。</p>
+      <p>その中心思想は、「攻撃コストの増大」ではなく「攻撃誘発要素の段階的無効化」にあります。従来の相互確証破壊ではなく、透明な連携と信頼構築を基礎にした多国間の共同オペレーションが要となります。</p>
+    </section>
+
+    <section>
+      <h2>ワルプルギス Ver.2.0の前提</h2>
+      <p>ワルプルギス Ver.2.0は、同時多発的なショックを前提に、社会・市場・人道の三領域を同時に安定化させるための設計思想です。単発の危機ではなく構造的な連鎖崩壊への備えとして、複層的なシナリオ分析と即応能力の整備が求められます。</p>
+    </section>
+  </main>
+  <footer>
+    <hr>
+    <p class="foot-link">用語が不明な場合は <a href="/thp/html/thp-5-glossary.html">THP-5 用語集</a> を参照。</p>
+  </footer>
+</body>
+</html>

--- a/thp/html/part2.html
+++ b/thp/html/part2.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>THP Part2 — 実装指針 / E-Penaltyの非暴力原則</title>
+  <meta name="description" content="THP実装指針。E-Penaltyは非暴力のミクロ秩序維持に限定し、E-MADとは領域を分離。用語・表記の統一を反映。">
+  <link rel="stylesheet" href="../styles/thp.css">
+</head>
+<body>
+  <header>
+    <h1>THP Part2 — 実装指針</h1>
+  </header>
+  <main>
+    <section>
+      <h2>Effective Multilateral Assured Denialとの分業</h2>
+      <p>THPの実装では、Effective Multilateral Assured Denial（E-MAD）が担う非暴力的抑止領域と、各地域統括が設計するE-Penaltyの領域を厳密に分離します。暴力的制裁は抑止ロジックを損ない、複合危機を加速させるためです。</p>
+    </section>
+
+    <section>
+      <h2>E-Penalty</h2>
+      <p>E-Penaltyは、制裁とE-MADが衝突しないよう<em>非暴力的措置</em>（信用スコア・取引条件のリスクプレミアム等）に限定します。逸脱はE-MADの管轄ではなく、各国の人倫評議会による審理に付す設計とします。</p>
+      <p>各地域統括と対象国は、透明性と正当性を確保しつつ、E-Penaltyの発動条件・評価指標・解除プロセスを共同で策定します。全ての手続きは監査可能でなければならず、被影響者に対する救済手段も併せて用意します。</p>
+    </section>
+
+    <section>
+      <h2>オペレーションガイドライン</h2>
+      <ul>
+        <li>各オペレーションは、多層的なセンシングデータに基づく相関監視を標準化します。</li>
+        <li>意図せぬエスカレーションを防ぐため、閾値設定は地域・社会状況を反映した段階制とします。</li>
+        <li>人道面の即応枠を常設し、非暴力抑止との両立を図ります。</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    <hr>
+    <p class="foot-link">用語が不明な場合は <a href="/thp/html/thp-5-glossary.html">THP-5 用語集</a> を参照。</p>
+  </footer>
+</body>
+</html>

--- a/thp/html/thp-5-glossary.html
+++ b/thp/html/thp-5-glossary.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>THP-5 — 用語集</title>
+  <meta name="description" content="THP用語集。E-MAD/E-Penaltyの新定義と表記統一を反映。">
+  <link rel="stylesheet" href="../styles/thp.css">
+</head>
+<body>
+  <header>
+    <h1>THP-5 — 用語集</h1>
+  </header>
+  <main>
+    <section>
+      <h2>A</h2>
+      <dl>
+        <dt>Alignment</dt>
+        <dd>THPが目指す政策・市場・人道の同時整合状態。領域間の衝突を避けるための基本指針。</dd>
+      </dl>
+    </section>
+
+    <section>
+      <h2>E</h2>
+      <dl>
+        <dt>E-MAD</dt>
+        <dd>Effective Multilateral Assured Denial。戦争抑止のための非暴力メカニズム。従来の“Economic ～”表記は使用しない。</dd>
+        <dt>E-Penalty</dt>
+        <dd>非暴力的ペナルティ体系。信用スコア調整・リスクプレミアム上乗せ等。ミクロの秩序維持として各地域統括×対象国が協議設計し、THPコアには実装しない。</dd>
+      </dl>
+    </section>
+
+    <section>
+      <h2>W</h2>
+      <dl>
+        <dt>ワルプルギス Ver.2.0</dt>
+        <dd>構造的・多起点ショックを想定した危機フレーム。複層的な断層が連鎖する事態に対応するための分析モデル。</dd>
+      </dl>
+    </section>
+  </main>
+</body>
+</html>

--- a/thp/html/thp-7-ops-kpi.html
+++ b/thp/html/thp-7-ops-kpi.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>THP-7 — Ops KPI Dashboard（運用計測基盤）</title>
+  <meta name="description" content="Gate群の複合監視（D/G/C/R/E）へ更新。ワルプルギス Ver.2.0に合わせ、相関監視と即応閾値を再定義。">
+  <link rel="stylesheet" href="../styles/thp.css">
+</head>
+<body>
+  <header>
+    <h1>THP-7 — Ops KPI Dashboard</h1>
+    <p class="rev">rev-2025.09.27 / Updated: <time datetime="2025-09-27">2025-09-27</time></p>
+  </header>
+  <main>
+    <section>
+      <h2>Gate群の複合監視</h2>
+      <p>Ops KPI Dashboardは、D/G/C/R/E（Diplomacy, Governance, Commerce, Relief, Energy）の各ゲートを複合監視します。ワルプルギス Ver.2.0のシナリオに合わせて、相関トリガーの再定義と即応閾値の見直しを実施しました。</p>
+    </section>
+
+    <section>
+      <h2>即応閾値の調整</h2>
+      <ul>
+        <li>リスクプレミアムの急騰を検知した場合、E-MADとの連携を即時稼働。</li>
+        <li>人道指標が閾値を下回った場合、E-Penaltyの適用条件を再評価し、救済措置を優先する。</li>
+        <li>各ゲート間の因果マップを更新し、疑似相関の排除と根因特定を高速化。</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    <hr>
+    <p class="foot-link">用語が不明な場合は <a href="/thp/html/thp-5-glossary.html">THP-5 用語集</a> を参照。</p>
+  </footer>
+</body>
+</html>

--- a/thp/styles/thp.css
+++ b/thp/styles/thp.css
@@ -1,0 +1,42 @@
+body {
+  font-family: "Noto Sans JP", system-ui, sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 2rem;
+  background-color: #f8f9fb;
+  color: #1a1a1a;
+}
+
+header h1 {
+  margin-bottom: 0.5rem;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.note {
+  background: #fff7e6;
+  border-left: 4px solid #f0b429;
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0;
+}
+
+.rev {
+  font-weight: 600;
+  color: #0a6ebd;
+}
+
+.foot-link {
+  font-size: 0.9rem;
+}
+
+.toc {
+  list-style: none;
+  padding-left: 0;
+}
+
+.toc li {
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add Horizon Protocol (THP) HTML pages covering overview, implementation guidance, glossary, KPI dashboard, and E-MAD specification with unified terminology
- publish a Japanese index page for the THP documents with revision metadata and glossary links
- update the site landing page metadata to describe the Horizon Protocol collection

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68d732b3aae08333aec5b0c8af603387