### PR TITLE
Add THP project index page with project summaries

### DIFF
--- a/Economy/0930/THP/THP-HTML/THP-Project/index.html
+++ b/Economy/0930/THP/THP-HTML/THP-Project/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>THP Project Index</title>
+    <link rel="stylesheet" href="/particle-musings/assets/styles/thp-project.css">
+  </head>
+  <body>
+    <main>
+      <h1>THPプロジェクト一覧</h1>
+
+      <h2>### Project 00 - ドルペッグ国救済プラン</h2>
+      <p class="pj-summary">GCC等のドルペッグ維持を円建て決済で橋渡しし、人道回廊を同時起動する即応パッケージ（BCH×JPYC×RORO）。</p>
+      <p>ドルペッグを維持するための金融調整と人道支援ルートの標準化に関する提案資料。</p>
+
+      <h2>### Project 01 - 日本救国プラン</h2>
+      <p class="pj-summary">決済・物流遮断や大規模流入時でも、生活（食・医・電・治安）を止めないための実務マニュアル群。</p>
+      <p>国内向けの危機対応マニュアルと訓練ドキュメントを整理し、平時から運用できる形に整備。</p>
+
+      <h2>### Project 02 - ライフラインインフラ構築</h2>
+      <p class="pj-summary">物流遮断時でも食料・医薬・電力・通信を確保するための時限インフラ圏の設計。</p>
+      <ul>
+        <li>資料１：ライフライン・インフラ構築圏に関する細則</li>
+        <li>資料２：T-5→T+90 行動計画</li>
+        <li>資料３：ライフライン・インフラ構築圏の設置及び運用に関する費用見積もり（清書版）</li>
+        <li>資料４：米国債市場における需給逼迫と決済機能不全リスクに関する分析報告（清書版）</li>
+      </ul>
+
+      <h2>### THP-DEATH回避策</h2>
+      <p class="pj-summary">初動10兆円（円建て）を一括前払し、対外交渉と人道支援を止めない資金動線の標準手順。</p>
+      <p>国際交渉と人道支援を同時に維持するための財政・外交アクションリスト。</p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a THP project index HTML page with summaries for projects 00–02 and the THP-DEATH plan
- use a root-relative stylesheet link so the project page can always load its CSS

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dbf6da76f883339a7a0a85456a1bf4